### PR TITLE
support Pytorch 1.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ It helps deverlopers to setup [PyTorch C++ Project](https://pytorch.org/cppdocs/
 2. Change `Project settings->Configuration Properties->Advanced->Target File Extension` to `dll`
 
 ## example
-'''
-extern "C" __declspec(dllexport) int check_cuda() 
+```C++
+extern "C" __declspec(dllexport) int check_cuda()
 {
     if (torch::cuda::is_available()) {
         return 1;
@@ -20,4 +20,4 @@ extern "C" __declspec(dllexport) int check_cuda()
         return 0;
     }
 }
-'''
+```

--- a/README.md
+++ b/README.md
@@ -3,3 +3,21 @@ It helps deverlopers to setup [PyTorch C++ Project](https://pytorch.org/cppdocs/
 
 # Visual Studio Extension Download Link
 [LibTorch Project Template](https://marketplace.visualstudio.com/items?itemName=YiZhang.LibTorch001)
+
+# How to build dll
+1. Change `Project settings->Configuration Properties->General->Configuration Type` to `Dynamic Library(.dll)`
+2. Change `Project settings->Configuration Properties->Advanced->Target File Extension` to `dll`
+
+## example
+'''
+extern "C" __declspec(dllexport) int check_cuda() 
+{
+    if (torch::cuda::is_available()) {
+        return 1;
+    }
+    else
+    {
+        return 0;
+    }
+}
+'''

--- a/VSIXTorch/ConfigForm.cs
+++ b/VSIXTorch/ConfigForm.cs
@@ -186,17 +186,24 @@
 
         private void btn_OK_Click(object sender, EventArgs e)
         {
+            if (String.IsNullOrWhiteSpace(this.txt_debug_dir.Text) && String.IsNullOrWhiteSpace(this.txt_release_dir.Text))
+            {
+                MessageBox.Show("At least one libtorch directory should be selected");
+                return;
+            }
+            if (String.IsNullOrWhiteSpace(this.txt_debug_dir.Text)) {
+                this.lbl_debug_torchversion.Text = string.Empty;
+            }
+            if (String.IsNullOrWhiteSpace(this.txt_release_dir.Text))
+            {
+                this.lbl_release_torchversion.Text = string.Empty;
+            }
             if (!String.IsNullOrWhiteSpace(this.lbl_debug_torchversion.Text) && !String.IsNullOrWhiteSpace(this.lbl_release_torchversion.Text))
             {
                 if (!String.Equals(lbl_debug_torchversion.Text, lbl_release_torchversion.Text)) {
                     MessageBox.Show("Debug version is different from Release version");
                     return;
                 }
-            }
-            if (String.IsNullOrWhiteSpace(this.txt_debug_dir.Text) && String.IsNullOrWhiteSpace(this.txt_release_dir.Text))
-            {
-                MessageBox.Show("At least one libtorch directory should be selected");
-                return;
             }
             if (this.chk_remember.Checked)
             {

--- a/VSIXTorch/vcproject.json
+++ b/VSIXTorch/vcproject.json
@@ -164,7 +164,174 @@
     },
     "link_options": "-INCLUDE:?warp_size@cuda@at@@YAHXZ;-INCLUDE:?searchsorted_cuda@native@at@@YA?AVTensor@2@AEBV32@0_N1@Z"
   },
+  "pytorch_setting_split_cuda_params_1": {
+    "includes": {
+      "cuda_dir": [
+        "include"
+      ],
+      "nvtools_dir": [
+        "include"
+      ],
+      "torch_dirs": [
+        "libtorch\\include",
+        "libtorch\\include\\torch\\csrc\\api\\include"
+      ]
+    },
+    "libs": {
+      "cuda_libs": [
+        "cublas.lib",
+        "cudart.lib",
+        "cudnn.lib",
+        "cufft.lib",
+        "curand.lib"
+      ],
+      "nvtools_libs": [
+        "nvToolsExt64_1.lib"
+      ],
+      "torch_libs": [
+        "caffe2_nvrtc.lib",
+        "c10.lib",
+        "c10_cuda.lib",
+        "kineto.lib>=1.9",
+        "torch.lib",
+        "torch_cpu.lib",
+        "torch_cuda.lib",
+        "torch_cuda_cpp.lib",
+        "torch_cuda_cu.lib"
+      ]
+    },
+    "link_options": "-INCLUDE:?warp_size@cuda@at@@YAHXZ;-INCLUDE:?_torch_cuda_cu_linker_symbol_op_cuda@native@at@@YA?AVTensor@2@AEBV32@@Z"
+  },
   "projects": {
+    "1.11": {
+      "cpu": {
+        "includes": {
+          "torch_dirs": [
+            "libtorch\\include",
+            "libtorch\\include\\torch\\csrc\\api\\include"
+          ]
+        },
+        "libs": {
+          "torch_libs": [
+            "c10.lib",
+            "torch.lib",
+            "torch_cpu.lib"
+          ]
+        }
+      },
+      "102": {
+        "includes": {
+          "cuda_dir": [
+            "include"
+          ],
+          "nvtools_dir": [
+            "include"
+          ],
+          "torch_dirs": [
+            "libtorch\\include",
+            "libtorch\\include\\torch\\csrc\\api\\include"
+          ]
+        },
+        "libs": {
+          "cuda_libs": [
+            "cublas.lib",
+            "cudart.lib",
+            "cudnn.lib",
+            "cufft.lib",
+            "curand.lib"
+          ],
+          "nvtools_libs": [
+            "nvToolsExt64_1.lib"
+          ],
+          "torch_libs": [
+            "caffe2_nvrtc.lib",
+            "c10.lib",
+            "c10_cuda.lib",
+            "kineto.lib>=1.9",
+            "torch.lib",
+            "torch_cpu.lib",
+            "torch_cuda.lib"
+          ]
+        },
+        "link_options": "-INCLUDE:?warp_size@cuda@at@@YAHXZ"
+      },
+      "111": {
+        "includes": {
+          "cuda_dir": [
+            "include"
+          ],
+          "nvtools_dir": [
+            "include"
+          ],
+          "torch_dirs": [
+            "libtorch\\include",
+            "libtorch\\include\\torch\\csrc\\api\\include"
+          ]
+        },
+        "libs": {
+          "cuda_libs": [
+            "cublas.lib",
+            "cudart.lib",
+            "cudnn.lib",
+            "cufft.lib",
+            "curand.lib"
+          ],
+          "nvtools_libs": [
+            "nvToolsExt64_1.lib"
+          ],
+          "torch_libs": [
+            "caffe2_nvrtc.lib",
+            "c10.lib",
+            "c10_cuda.lib",
+            "kineto.lib>=1.9",
+            "torch.lib",
+            "torch_cpu.lib",
+            "torch_cuda.lib",
+            "torch_cuda_cpp.lib",
+            "torch_cuda_cu.lib"
+          ]
+        },
+        "link_options": "-INCLUDE:?warp_size@cuda@at@@YAHXZ;-INCLUDE:?_torch_cuda_cu_linker_symbol_op_cuda@native@at@@YA?AVTensor@2@AEBV32@@Z"
+      },
+      "113": {
+        "includes": {
+          "cuda_dir": [
+            "include"
+          ],
+          "nvtools_dir": [
+            "include"
+          ],
+          "torch_dirs": [
+            "libtorch\\include",
+            "libtorch\\include\\torch\\csrc\\api\\include"
+          ]
+        },
+        "libs": {
+          "cuda_libs": [
+            "cublas.lib",
+            "cudart.lib",
+            "cudnn.lib",
+            "cufft.lib",
+            "curand.lib"
+          ],
+          "nvtools_libs": [
+            "nvToolsExt64_1.lib"
+          ],
+          "torch_libs": [
+            "caffe2_nvrtc.lib",
+            "c10.lib",
+            "c10_cuda.lib",
+            "kineto.lib>=1.9",
+            "torch.lib",
+            "torch_cpu.lib",
+            "torch_cuda.lib",
+            "torch_cuda_cpp.lib",
+            "torch_cuda_cu.lib"
+          ]
+        },
+        "link_options": "-INCLUDE:?warp_size@cuda@at@@YAHXZ;-INCLUDE:?_torch_cuda_cu_linker_symbol_op_cuda@native@at@@YA?AVTensor@2@AEBV32@@Z"
+      }
+    },
     "1.10": {
       "cpu": {
         "includes": {

--- a/VSIXTorch/vcproject.yml
+++ b/VSIXTorch/vcproject.yml
@@ -72,7 +72,18 @@ pytorch_setting_split_cuda_params: &pytorch_setting_split_cuda_params
     libs: *setting_torch_split_gpu_libs
     link_options: -INCLUDE:?warp_size@cuda@at@@YAHXZ;-INCLUDE:?searchsorted_cuda@native@at@@YA?AVTensor@2@AEBV32@0_N1@Z
 
+# since pytorch 1.11
+pytorch_setting_split_cuda_params_1: &pytorch_setting_split_cuda_params_1
+    includes: *setting_gpu_includes
+    libs: *setting_torch_split_gpu_libs
+    link_options: -INCLUDE:?warp_size@cuda@at@@YAHXZ;-INCLUDE:?_torch_cuda_cu_linker_symbol_op_cuda@native@at@@YA?AVTensor@2@AEBV32@@Z
+
 projects:
+    1.11:
+        cpu: *pytorch_setting_cpu_params
+        102: *pytorch_setting_cuda_params
+        111: *pytorch_setting_split_cuda_params_1
+        113: *pytorch_setting_split_cuda_params_1
     1.10:
         cpu: *pytorch_setting_cpu_params
         102: *pytorch_setting_cuda_params


### PR DESCRIPTION
update additional link option is  `-INCLUDE:?warp_size@cuda@at@@YAHXZ;-INCLUDE:?_torch_cuda_cu_linker_symbol_op_cuda@native@at@@YA?AVTensor@2@AEBV32@@Z`